### PR TITLE
Add hacky interop parser.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,9 @@ else
 	git clone -q --depth 10 $(CLONE_ARGS) \
 	    -b main https://github.com/martinthomson/i-d-template $(LIBDIR)
 endif
+
+.PHONY: interop
+interop:
+	@err=0; for f in $(drafts_source); do \
+		python interop/parse_interop_tags.py $$f interop/tests/; \
+	done

--- a/interop/parse_interop_tags.py
+++ b/interop/parse_interop_tags.py
@@ -3,24 +3,6 @@ import os
 import sys
 import json
 
-'''
-export default
-{
-  name: 'Connect-UDP',
-  id: 'connect-udp',
-  description: 'Specification support for draft-ietf-masque-connect-udp-00',
-  tests: [
-    {
-      name: 'The client supports CONNECT-UDP over HTTP/3',
-      id: 'connect-udp-h3-client',
-      kind: 'supported',
-    },
-    ... 
-  ]
-
-  [{'req-id': 'connect-udp-quic-client-cid', 'req': 'Client sends `Client-Connection-Id` in first `CONNECT-UDP` request', 'req-type': 'must'}]
-}
-'''
 def options_to_tests(fname, output_path, options):
     tests = []
     for option in options:
@@ -32,7 +14,7 @@ def options_to_tests(fname, output_path, options):
     data = {
         "name": draft_title(fname),
         "id": draft_to_test_name(fname),
-        "description": "TBD",
+        "description": "Interoperability test results for " + draft_title(fname),
         "tests": tests
     }
 

--- a/interop/parse_interop_tags.py
+++ b/interop/parse_interop_tags.py
@@ -1,0 +1,65 @@
+import re
+import os
+import sys
+import json
+
+'''
+export default
+{
+  name: 'Connect-UDP',
+  id: 'connect-udp',
+  description: 'Specification support for draft-ietf-masque-connect-udp-00',
+  tests: [
+    {
+      name: 'The client supports CONNECT-UDP over HTTP/3',
+      id: 'connect-udp-h3-client',
+      kind: 'supported',
+    },
+    ... 
+  ]
+
+  [{'req-id': 'connect-udp-quic-client-cid', 'req': 'Client sends `Client-Connection-Id` in first `CONNECT-UDP` request', 'req-type': 'must'}]
+}
+'''
+def options_to_tests(fname, output_path, options):
+    tests = []
+    for option in options:
+        tests.append({
+            "name": option["req"],
+            "id": option["req-id"],
+            "kind": option["req-type"],
+        })
+    data = {
+        "name": draft_title(fname),
+        "id": draft_to_test_name(fname),
+        "description": "TBD",
+        "tests": tests
+    }
+
+    with open(os.path.join(output_path, draft_to_test_name(fname)), "w") as fh:
+        fh.write("export default\n")
+        fh.write(json.dumps(data, indent=4))
+
+def draft_to_test_name(fname):
+    return os.path.basename(fname).split(".")[0] + ".mjs"
+
+def draft_title(fname):
+    with open(fname, "r") as fh:
+        return re.search(r'title: (.*?)\n', fh.read()).group(1).strip()
+
+draft_name = sys.argv[1]
+output_path = sys.argv[2]
+with open(draft_name, "r") as fh:
+    filedata = fh.read()
+    option_pattern = re.compile(r'\{::options(.*?)/\}')
+    options = []
+    for option in re.findall(option_pattern, filedata):
+        data = option.split(" ")
+        entry = {}
+        pattern = re.compile(r' (.*?)=\"(.*?)\"')
+        for k, v in re.findall(pattern, option):
+            entry[k] = v
+        options.append(entry)
+    
+    options_to_tests(draft_name, output_path, options)
+


### PR DESCRIPTION
This spits out:

```
├── interop
│   └── tests
│       ├── connect-udp.mjs
│       ├── draft-pauly-masque-quic-proxy.mjs
│       └── index.mjs
```

With contents:

```
export default
{
    "description": "TBD", 
    "tests": [
        {
            "kind": "must", 
            "name": "Client sends `Client-Connection-Id` in first `CONNECT-UDP` request", 
            "id": "connect-udp-quic-client-cid"
        }
    ], 
    "name": "QUIC-Aware Proxying Using CONNECT-UDP", 
    "id": "draft-pauly-masque-quic-proxy.mjs"
}
```