### PR TITLE
Adopt capsules for QUIC-aware proxying

### DIFF
--- a/draft-pauly-masque-quic-proxy.md
+++ b/draft-pauly-masque-quic-proxy.md
@@ -1,5 +1,5 @@
 ---
-title: QUIC-Aware Proxying Using CONNECT-UDP
+title: QUIC-Aware Proxying Using HTTP
 abbrev: QUIC Proxy
 docname: draft-pauly-masque-quic-proxy-latest
 category: exp
@@ -32,8 +32,8 @@ author:
 
 --- abstract
 
-This document defines an extension to the CONNECT-UDP HTTP method that adds
-specific optimizations for QUIC connections that are proxied. This extension
+This document defines an extension to the UDP over HTTP Extended CONNECT protocol
+that adds specific optimizations for proxied QUIC connections. This extension
 allows a proxy to reuse UDP 4-tuples for multiple connections. It also defines a
 mode of proxying in which QUIC short header packets can be forwarded through the
 proxy rather than being re-encapsulated and re-encrypted.
@@ -42,25 +42,21 @@ proxy rather than being re-encapsulated and re-encrypted.
 
 # Introduction {#introduction}
 
-The CONNECT-UDP HTTP method {{!CONNECT-UDP=I-D.ietf-masque-connect-udp}} defines
-a way to send datagrams through an HTTP proxy, where UDP is used to communicate
+The UDP over HTTP Extended CONNECT protocol {{!CONNECT-UDP=I-D.ietf-masque-connect-udp}}
+defines a way to send datagrams through an HTTP proxy, where UDP is used to communicate
 between the proxy and a target server. This can be used to proxy QUIC
-connections {{!QUIC=I-D.ietf-quic-transport}}, since QUIC runs over UDP
-datagrams.
+connections {{!QUIC=RFC9000}}, since QUIC runs over UDP datagrams.
 
 This document uses the term "target" to refer to the server that a client is
 accessing via a proxy. This target may be an origin hosting content, or another
 proxy.
 
-This document extends the CONNECT-UDP HTTP method to add signalling about QUIC
+This document extends the UDP proxying protocol to add signalling about QUIC
 Connection IDs. QUIC Connection IDs are used to identify QUIC connections in
 scenarios where there is not a strict bidirectional mapping between one QUIC
 connection and one UDP 4-tuple (pairs of IP addresses and ports). A proxy that
 is aware of Connection IDs can reuse UDP 4-tuples between itself and a target
 for multiple proxied QUIC connections.
-
-This extension is only defined for HTTP/3 {{!HTTP3=I-D.ietf-quic-http}} and not
-any earlier versions.
 
 Awareness of Connection IDs also allows a proxy to avoid re-encapsulation and
 re-encryption of proxied QUIC packets once a connection has been established.
@@ -70,7 +66,7 @@ QUIC packets:
 1. Tunnelled, in which client <-> target QUIC packets are encapsulated inside
 client <-> proxy QUIC packets. These packets use multiple layers of encryption
 and congestion control. QUIC long header packets MUST use this mode. QUIC short
-header packets MAY use this mode. This is the default mode for CONNECT-UDP.
+header packets MAY use this mode. This is the default mode for UDP proxying.
 
 2. Forwarded, in which client <-> target QUIC packets are sent directly over the
 client <-> proxy UDP socket. These packets are only encrypted using the
@@ -100,9 +96,12 @@ links. See {{security}} for further discussion.
 Both clients and proxies can unilaterally choose to disable forwarded mode for
 any client <-> target connection.
 
+The forwarding mode of this extension is only defined for HTTP/3
+{{!HTTP3=I-D.ietf-quic-http}} and not any earlier versions.
+
 QUIC proxies only need to understand the Header Form bit, and the connection ID
 fields from packets in client <-> target QUIC connections. Since these fields
-are all in the QUIC invariants header {{!INVARIANTS=I-D.ietf-quic-invariants}},
+are all in the QUIC invariants header {{!INVARIANTS=RFC8999}},
 QUIC proxies can proxy all versions of QUIC.
 
 ## Conventions and Definitions {#conventions}
@@ -117,11 +116,11 @@ when, and only when, they appear in all capitals, as shown here.
 This document uses the following terms:
 
 - Client: the client of all QUIC connections discussed in this document.
-- Proxy: the endpoint that responds to the CONNECT-UDP request.
+- Proxy: the endpoint that responds to the Extended CONNECT request.
 - Target: the server that a client is accessing via a proxy.
 - Client <-> Proxy QUIC connection: a single QUIC connection established from
 the client to the proxy.
-- Datagram flow ID: represents a flow of HTTP/3 DATAGRAMs
+- Quarter stream ID: represents a set of HTTP/3 DATAGRAMs
 {{!H3DGRAM=I-D.schinazi-quic-h3-datagram}} specific to a single client <-> proxy
 QUIC connection.
 - Socket: a UDP 4-tuple (local IP address, local UDP port, remote IP address,
@@ -156,20 +155,20 @@ In order to correctly route QUIC packets in both tunnelled and forwarded modes,
 the proxy needs to maintain mappings between several items. There are three
 required unidirectional mappings, described below.
 
-## Datagram Flow ID Mapping
+## Quarter Stream ID Mapping
 
-Each pair of client <-> proxy QUIC connection and datagram flow ID MUST be
-mapped to a single server-facing socket.
+Each pair of client <-> proxy QUIC connection and quarter stream ID
+MUST be mapped to a single server-facing socket.
 
 ~~~
-(Client <-> Proxy QUIC connection + Datagram flow ID)
+(Client <-> Proxy QUIC connection + Quarter stream ID)
     => Server-facing socket
 ~~~
 
-Multiple datagram flow IDs can map to the same server-facing socket, but a
-single datagram flow ID cannot be mapped to multiple server-facing sockets.
+Multiple quarter stream IDs can map to the same server-facing socket, but a
+single quarter stream ID cannot be mapped to multiple server-facing sockets.
 
-This mapping guarantees that any QUIC packet using the datagram flow ID sent
+This mapping guarantees that any datagram using a quarter stream ID sent
 from the client to the proxy in tunnelled mode can be sent to the correct
 target.
 
@@ -194,24 +193,24 @@ maintain this mapping.
 ## Client Connection ID Mappings
 
 Each pair of Client Connection ID and server-facing socket MUST map to a single
-datagram flow ID on a single client <-> proxy QUIC connection. Additionally, the
+quarter stream ID on a single client <-> proxy QUIC connection. Additionally, the
 pair of Client Connection ID and server-facing socket MUST map to a single
 client-facing socket.
 
 ~~~
 (Server-facing socket + Client Connection ID)
-    => (Client <-> Proxy QUIC connection + Datagram flow ID)
+    => (Client <-> Proxy QUIC connection + Quarter stream ID)
 (Server-facing socket + Client Connection ID)
     => Client-facing socket
 ~~~
 
-Multiple pairs of Connection IDs and sockets can map to the same datagram flow
+Multiple pairs of Connection IDs and sockets can map to the same quarter stream
 ID or client-facing socket.
 
 These mappings guarantee that any QUIC packet sent from a target to the proxy
 can be sent to the correct client, in either tunnelled or forwarded mode. Note
 that this mapping becomes trivial if the proxy always opens a new server-facing
-socket for every client request with a unique datagram flow ID. The mapping is
+socket for every client request with a unique quarter stream ID. The mapping is
 critical for any case where server-facing sockets are shared or reused.
 
 ## Detecting Connection ID Conflicts {#conflicts}
@@ -242,107 +241,117 @@ conflicts. Note that a request that doesn't contain any Connection ID is
 equivalent to a request for a zero-length Connection ID, and similarly would
 cause conflicts when forwarding.
 
-# Connection ID Headers for CONNECT-UDP
+# Connection ID Capsule Types
 
-This document defines two headers that can be used in CONNECT-UDP requests
-and responses. All other requirements defined for CONNECT-UDP {{CONNECT-UDP}}
-still apply.
+Proxy awareness of QUIC Connection IDs relies on using capsules ({{H3DGRAM}}
+to signal the addition and removal of client and server connection IDs.
 
-Both "Client-Connection-Id" and "Server-Connection-Id" are Item Structured
-Headers {{!STRUCT=I-D.ietf-httpbis-header-structure}}.  Their value MUST be a
-Byte Sequence. The byte sequence MAY be zero-length. The byte sequence length
-MUST NOT exceed 255 bytes. The ABNF is:
+Note that these capsules do not register contexts or define a new HTTP Datagram
+Format. By default, QUIC packets are encoded using HTTP Datagrams with the
+UDP_PAYLOAD HTTP Datagram Format Type as defined in {{CONNECT-UDP}}.
+
+The capsules used for QUIC-aware proxying allow a client to register connection
+IDs with the proxy, and for the proxy to acknowledge or reject the connection
+ID mappings.
+
+## Register and Acknowlege Connection ID Capsule Types
+
+The REGISTER_CLIENT_CID and REGISTER_SERVER_CID capsule types (see 
+{{iana-capsule-types}} for the capsule type values) allow a client to inform
+the proxy about a new Client Connection ID or a new Server Connection ID,
+respectively.
+
+The ACK_CLIENT_CID and ACK_SERVER_CID capsule types (see {{iana-capsule-types}}
+for the capsule type values) are sent by the proxy to the client to indicate
+that a mapping was successfully created for a registered connection ID.
+
+Register and Ack Connection ID capsule types share the same format:
 
 ~~~
-   Client-Connection-Id = sf-binary
-   Server-Connection-Id = sf-binary
+Connection ID Capsule {
+  Type (i) = 0xffe100..0xffe103,
+  Length (i),
+  Connection ID Length (8),
+  Connection ID (0..160),
+}
 ~~~
+{: #fig-capsule-cid title="Connection ID Capsule Format"}
 
-"Client-Connection-Id" contains the client connection ID, whereas
-"Server-Connection-Id" contains the server connection ID.
+Connection ID Length:
+: An 8-bit unsigned integer containing the length of the connection ID.
+Values less than 1 and greater than 20 are invalid.
 
-Like the Datagram-Flow-Id header {{CONNECT-UDP}}, the Client-Connection-Id and
-Server-Connection-Id headers can only be supported by an HTTP/3 proxy. If a
-proxy does not support HTTP/3 datagrams {{H3DGRAM}}, or it does not support the
-extension defined in this document, it MUST NOT send the Client-Connection-Id
-and Server-Connection-Id headers on any responses. If a proxy does support this
-extension, it MUST echo the Client-Connection-Id and Server-Connection-Id
-headers on any 2xx (Successful) responses. Clients that do not receive an echoed
-Client-Connection-Id or Server-Connection-Id header MUST fall back to using
-CONNECT-UDP without the extended behavior defined in this document.
+Connection ID:
+: A connection ID of the specified length.
+
+## Close Connection ID Capsule Types {#close-capsule}
+
+The CLOSE_CLIENT_CID and CLOSE_SERVER_CID capsule types (see 
+{{iana-capsule-types}} for the capsule type values) allow either a client
+or a proxy to remove a mapping for a connection ID. These capsules share
+the following format:
+
+~~~
+Connection ID Capsule {
+  Type (i) = 0xffe104..0xffe105,
+  Length (i),
+  Connection ID Length (8),
+  Connection ID (0..160),
+  Close Code (i),
+  Close Details (..),
+}
+~~~
+{: #fig-capsule-close-cid title="Close Connection ID Capsule Format"}
+
+Close Code:
+: The close code allows an endpoint to provide additional information as
+to why a connection ID mapping was closed. The codes are defined in
+{{iana-close-codes}}.
+
+Close Details:
+: This is meant for debugging purposes. It consists of a human-readable
+string encoded in UTF-8.¶
+
+Connection ID Length:
+: An 8-bit unsigned integer containing the length of the connection ID.
+Values less than 1 and greater than 20 are invalid.
+
+Connection ID:
+: A connection ID of the specified length.
 
 # Client Request Behavior {#request}
 
-A client sends new CONNECT-UDP requests when it wants to start
-a new QUIC connection to a target, when it has received a new
-Server Connection ID for the target, and before it advertises a new Client
-Connection ID to the target.
-
-Each request MUST contain a Datagram-Flow-Id header and an authority
-pseudo-header identifying the target. All requests for the same QUIC
-Connection between a client and a target MUST contain the same authority,
-and SHOULD contain the same Datagram-Flow-Id. If there is Datagram-Flow-Id
-mismatch, the proxy will treat the requests as different proxied connections,
-which could appear as a migration or NAT rebinding event to the target.
-{::options req-id="connect-udp-datagram-flow-id" req-type="must" req="Client sends `Datagram-Flow-Id` in all `CONNECT-UDP` requests" /}
-{::options req-id="connect-udp-authority" req-type="must" req="Client sends the same `:authority` in all requests for the same connection" /}
-{::options req-id="connect-udp-datagram-flow-id-match" req-type="should" req="Client sends the same `Datagram-Flow-Id` in all requests for the same connection" /}
-
-Each request MUST also contain exactly one connection ID header, either
-Client-Connection-Id or Server-Connection-Id. Client-Connection-Id requests
-define paths for receiving packets from the target server to the client, and
-Server-Connection-Id requests define paths for sending packets from the client
-to target server.
-{::options req-id="connect-udp-quic-cids" req-type="must" req="Client sends exactly one  `*-Connection-Id ` in each request" /}
+A client initiates UDP proxying via an extended CONNECT request as defined
+in {{CONNECT-UDP}}. It then sends a REGISTER_CLIENT_CID capsule whenever it
+advertises a new Client Connection ID to the target, and a REGISTER_SERVER_CID
+capsule when it has received a new Server Connection ID for the target.
 
 ## New Proxied Connection Setup
 
-The first time that a client uses a proxy for a given QUIC connection, it
-selects a new datagram flow ID with an even-numbered value {{H3DGRAM}}.
+To initiate QUIC-aware proxying, the client sends a REGISTER_CLIENT_CID
+capsule containing the initial Client Connection ID that the client has
+advertised to the target.
 
-The first request the clients makes MUST contain the authority pseudo-header,
-the Datagram-Flow-Id header, and the Client-Connection-Id header. These
-respectively contain the authority of the target, the selected datagram
-flow ID and the Client Connection ID that will be used in the initial QUIC
-packets sent through the proxy.
-{::options req-id="connect-udp-quic-client-cid" req-type="must" req="Client sends `Client-Connection-Id` in first `CONNECT-UDP` request" /}
-
-The client can start sending packets tunnelled within DATAGRAM frames as soon as
-this first CONNECT-UDP request for the datagram flow ID has been sent, even in
-the same QUIC packet to the proxy. That is, the QUIC packet sent from the client
-to the proxy MAY contain a STREAM frame containing the CONNECT-UDP request, as
-well as a DATAGRAM frame that contains a tunnelled QUIC packet to send to the
-target. This is particularly useful for reducing round trips on connection
-setup.
-{::options req-id="connect-udp-early-data" req-type="supported" req="Client sends `DATAGRAM` frames in the same flight as the `CONNECT-UDP` request" /}
+If the mapping is created successfully, the client will receive a
+ACK_CLIENT_CID capsule that contains the same connection ID that was
+requested.
 
 Since clients are always aware whether or not they are using a QUIC proxy,
 clients are expected to cooperate with proxies in selecting Client Connection
 IDs. A proxy detects a conflict when it is not able to create a unique mapping
 using the Client Connection ID ({{conflicts}}). It can reject requests that
-would cause a conflict and indicate this to the client by replying with a 409
-(Conflict) status. In order to avoid conflicts, clients SHOULD select Client
-Connection IDs of at least 8 bytes in length with unpredictable values. A client
-also SHOULD NOT select a Client Connection ID that matches the ID used for the
-QUIC connection to the proxy, as this inherently creates a conflict.
+would cause a conflict and indicate this to the client by replying with a
+CLOSE_CLIENT_CID capsule, with the close code set to CONFLICT. In order to
+avoid conflicts, clients SHOULD select Client Connection IDs of at least 8
+bytes in length with unpredictable values. A client also SHOULD NOT select
+a Client Connection ID that matches the ID used for the QUIC connection to
+the proxy, as this inherently creates a conflict.
 
-Note that packets sent in DATAGRAM frames before the proxy has sent its
-CONNECT-UDP response might be dropped if the proxy rejects the request.
-Specifically, this can occur if the Client Connection ID causes a conflict and
-the proxy returns a 409 (Conflict) error. Any DATAGRAM frames that are sent in a
-separate QUIC packet from the STREAM frame that contains the CONNECT-UDP request
-might also be dropped in the case that the packet arrives at the proxy before
-the packet containing the STREAM frame.
-
-If the server rejects the first request that uses a specific datagram flow ID,
-the client MUST retire that datagram flow ID. If the rejection indicated a
-conflict due to the Client Connection ID, the client MUST select a new
-Connection ID before sending a new request, and generate a new packet. For
-example, if a client is sending a QUIC Initial packet and chooses a Connection
-ID that conflicts with an existing mapping to the same target server, it will
-need to generate a new QUIC Initial.
-{::options req-id="connect-udp-rejected-flow-id" req-type="must" req="Client does not reuse a `Datagram-Flow-Id` that has been rejected" /}
-{::options req-id="connect-udp-rejected-conn-id" req-type="must" req="Client does not reuse a `Client-Connection-Id` that has been rejected" /}
+If the rejection indicated a conflict due to the Client Connection ID, the
+client MUST select a new Connection ID before sending a new request, and
+generate a new packet. For example, if a client is sending a QUIC Initial
+packet and chooses a Connection ID that conflicts with an existing mapping
+to the same target server, it will need to generate a new QUIC Initial.
 
 ## Adding New Client Connection IDs
 
@@ -351,34 +360,31 @@ communicate its chosen connection IDs to its peer before the peer can start
 using them. In QUICv1, this is performed using the NEW_CONNECTION_ID frame.
 
 Prior to informing the target of a new chosen client connection ID, the client
-MUST send a CONNECT-UDP request with the Client-Connection-Id header to the
-proxy, and only inform the target of the new client connection ID once a 2xx
-(Successful) response is received.
-{::options req-id="connect-udp-new-client-cid" req-type="must" req="Client sends a new request prior to sending `NEW_CONNECTION_ID` frames" /}
+MUST send a REGISTER_CLIENT_CID capsule request containing the new Client
+Connection ID.
+
+The client should only inform the target of the new Client Connection ID once a
+ACK_CLIENT_CID capsule is received that contains the echoed connection ID.
 
 ## Sending With Forwarded Mode
 
 Once the client has learned the target server's Connection ID, such as in the
-response to a QUIC Initial packet, it can send a request containing the
-Server-Connection-Id header to request the ability to forward packets. The
-client MUST wait for a successful (2xx) response before using forwarded mode.
+response to a QUIC Initial packet, it can send a REGISTER_SERVER_CID capsule
+containing the Server Connection ID to request the ability to forward packets. 
+
+The client MUST wait for a ACK_SERVER_CID capsule that contains the echoed
+connection ID before using forwarded mode.
+
 Prior to receiving the server response, the client MUST send short header
 packets tunnelled in DATAGRAM frames. The client MAY also choose to tunnel some
 short header packets even after receiving the successful response.
-{::options req-id="connect-udp-forwarded-mode" req-type="supported" req="Client supports forwarded mode" /}
-{::options req-id="connect-udp-forwarded-sh" req-type="must" req="Client only uses forwarded mode with short header packets" /}
-{::options req-id="connect-udp-forwarded-sh-wait" req-type="must" req="Client does not use forwarded mode prior to receiving a `2xx (OK)`" /}
 
-If the client's request that included the Server-Connection-Id is rejected, for
-example with a 409 (Conflict) response, it MUST NOT forward packets to the
-requested Server Connection ID, but only use tunnelled mode. The request might
+If the Server Connection ID registration is rejected, for example with a
+CONFLICT close code in a CLOSE_SERVER_CID capsule, it MUST NOT forward packets to
+the requested Server Connection ID, but only use tunnelled mode. The request might
 also be rejected if the proxy does not support forwarded mode or has it disabled
-by policy. For any response code other than a 2xx success, the client MUST NOT
-retry a request for the same Server Connection ID. For errors other than 409
-(Conflict), clients SHOULD stop sending requests for other Server Connection IDs
-in the future.
-{::options req-id="connect-udp-forwarded-rejected" req-type="must" req="Client does not use forwarded mode if the server sends a `409 (Conflict)`" /}
-{::options req-id="connect-udp-forwarded-stop" req-type="should" req="Client stops sending requests for forwarded mode if the server sends an error other than `409 (Conflict)`" /}
+by policy. For close codes other than CONFLICT, clients SHOULD stop sending requests
+for other Server Connection IDs in the future.
 
 QUIC long header packets MUST NOT be forwarded. These packets can only be
 tunnelled within DATAGRAM frames to avoid exposing unnecessary connection
@@ -400,40 +406,30 @@ forwarded short header packets on the socket between itself and the proxy for
 any Client Connection ID that has been accepted by the proxy. The client uses
 the received Connection ID to determine if a packet was originated by the
 proxy, or merely forwarded from the target.
-{::options req-id="connect-udp-forwarded-receive" req-type="must" req="Client supports receiving forwarded packets from proxy" /}
 
 ## Opting Out of Forwarded Mode
 
 The use of forwarded mode is initiated by the client sending a request with the
-Server-Connection-Id header and sending at least one forwarded packet to the
+REGISTER_SERVER_CID capsule and sending at least one forwarded packet to the
 proxy. A client that does not wish to accept forwarded packets from the proxy
 when communicating with a specific target can simply not start forwarding
 packets to the proxy.
 
 # Proxy Response Behavior {#response}
 
-Upon receipt of a CONNECT-UDP request that contains a Client-Connection-Id or
-Server-Connection-Id header, the proxy validates the request, tries to
-establish the appropriate mappings as described in {{mappings}}, and
-establishes a new server-facing socket if necessary.
-
-The proxy MUST validate that the request only contains one of either the
-Client-Connection-Id or the Server-Connection-Id header, along with a
-Datagram-Flow-Id header and an authority pseudo-header. If any of these
-conditions is not met, the proxy MUST reject the request with a 400 (Bad
-Request) response. The proxy also MUST reject the request if the requested
-datagram flow ID has already been used on that client <-> proxy QUIC connection
-with a different requested authority.
-{::options req-id="connect-udp-headers-validate" req-type="must" req="Proxy rejects requests without correct headers with `400 (Bad Request)`" /}
+Upon receipt of a REGISTER_CLIENT_CID or REGISTER_SERVER_CID capsule,
+Sthe proxy validates the registration, tries to establish the appropriate
+mappings as described in {{mappings}}, and establishes a new server-facing
+socket if necessary.
 
 The proxy then determines the server-facing socket to associate with the
-client's datagram flow. This will generally involve performing a DNS lookup for
-the hostname in the request authority, or finding an existing server-facing
+client's request. This will generally involve performing a DNS lookup for
+the hostname in the CONNECT request authority, or finding an existing server-facing
 socket to the authority. The server-facing socket might already be open due to a
 previous request from this client, or another. If the socket is not already
 created, the proxy creates a new one. Proxies can choose to reuse server-facing
-sockets across multiple datagram flows, or have a unique server-facing socket
-for every datagram flow.
+sockets across multiple datagram contexts, or have a unique server-facing socket
+for every datagram context.
 
 If a proxy reuses server-facing sockets, it SHOULD store which authorities
 (which could be a domain name or IP address literal) are being accessed over a
@@ -441,71 +437,58 @@ particular server-facing socket so it can avoid performing a new DNS query and
 potentially choosing a different server IP address which could map to a
 different server.
 
-Server-facing sockets MUST NOT be reused across QUIC and non-QUIC CONNECT-UDP
+Server-facing sockets MUST NOT be reused across QUIC and non-QUIC UDP proxy
 requests, since it might not be possible to correctly demultiplex or direct
 the traffic. Any packets received on a server-facing socket used for proxying
 QUIC that does not correspond to a known Connection ID MUST be dropped.
 
-If the request includes a Client-Connection-Id header, the proxy is receiving a
+When the proxy recieves a REGISTER_CLIENT_CID capsule, it is receiving a
 request to be able to route traffic back to the client using that Connection ID.
 If the pair of this Client Connection ID and the selected server-facing socket
 does not create a conflict, the proxy creates the mapping and responds with a
-200 (OK) response. After this point, any packets received by the proxy from the
+ACK_CLIENT_CID capsule. After this point, any packets received by the proxy from the
 server-facing socket that match the Client Connection ID can to be sent to the
 client. The proxy MUST use tunnelled mode (DATAGRAM frames) on the correct
-datagram flow for any long header packets. The proxy SHOULD forward directly to
+datagram context for any long header packets. The proxy SHOULD forward directly to
 the client for any matching short header packets, but MAY tunnel them in
 DATAGRAM frames. If the pair is not unique, or the proxy chooses not to support
-zero-length Client Connection IDs, the proxy responds with a 409 (Conflict)
-response. If this occurs on the first request for a given datagram flow, the
-proxy removes any mapping for that datagram flow.
+zero-length Client Connection IDs, the proxy responds with a CLOSE_CLIENT_CID
+capsule with a CONFLICT close code. If this occurs on the first request for a
+given HTTP request, the proxy removes any mapping for that HTTP request.
 
-If the request includes a Server-Connection-Id header, the proxy is receiving a
+When the proxy recieves a REGISTER_SERVER_CID capsule, it is receiving a
 request to allow the client to forward packets to the target. If the pair of
 this Server Connection ID and the client-facing socket on which the request was
 received does not create a conflict, the proxy creates the mapping and responds
-with a 200 (OK) response. Once the successful response is sent, the proxy will
+with a ACK_SERVER_CID capsule. Once the successful response is sent, the proxy will
 forward any short header packets received on the client-facing socket that use
 the Server Connection ID using the correct server-facing socket. If the pair is
-not unique, the server responds with a 409 (Conflict) response. If this occurs,
-traffic for that Server Connection ID can only use tunnelled mode, not
-forwarded.
-{::options req-id="connect-udp-proxy-forwarded-mode" req-type="supported" req="Proxy supports forwarded mode" /}
+not unique, the server responds with a CLOSE_SERVER_CID capsule with a CONFLICT
+close code. If this occurs, traffic for that Server Connection ID can only use
+tunnelled mode, not forwarded.
 
 If the proxy does not support forwarded mode, or does not allow forwarded mode
-for a particular client or authority by policy, it can reject requests that
-include the Server-Connection-Id header with a response to indicate the error,
-such as 403 (Forbidden).
-
-Any successful (2xx) response MUST also echo any Client-Connection-Id,
-Server-Connection-Id, and Datagram-Flow-Id headers included in the request.
-{::options req-id="connect-udp-headers-echo" req-type="must" req="Proxy echoes `Datagram-Flow-Id` and `*-Connection-Id` headers in successful replies" /}
+for a particular client or authority by policy, it can reject REGISTER_SERVER_CID
+requests with a DENIED close code.
 
 The proxy MUST only forward non-tunnelled packets from the client that are QUIC
 short header packets (based on the Header Form bit) and have mapped Server
 Connection IDs. Packets sent by the client that are forwarded SHOULD be
 considered as activity for restarting QUIC's Idle Timeout {{QUIC}}.
-{::options req-id="connect-udp-proxy-idle" req-type="should" req="Proxy uses forwarded packets to restart its idle timeout" /}
 
 ## Removing Mapping State
 
-Each CONNECT-UDP request consumes one bidirectional HTTP/3 stream {{HTTP3}}.
-For any stream on which the proxy has sent a response indicating success, any
-mappings for the request last as long as the stream is open.
+For any connection ID for which the proxy has sent an acknowledgement, any
+mappings for the connection ID last until either endpoint sends a close capsule
+or the entire HTTP request stream closes.
 
 A client that no longer wants a given Connection ID to be forwarded by the
-proxy, for either direction, MUST cancel its CONNECT-UDP HTTP/3 request by
-closing the corresponding stream.
-
-If the proxy rejects a CONNECT-UDP request by sending a status code of 300 or
-higher, it MUST close the corresponding stream and remove any associated
-mappings.
-{::options req-id="connect-udp-close-stream" req-type="must" req="Proxy closes HTTP stream when it rejects a `CONNECT-UDP` request" /}
+proxy sends a CLOSE_CLIENT_CID or CLOSE_SERVER_CID capsule.
 
 If a client's connection to the proxy is terminated for any reason, all
 mappings associated with all requests are removed.
 
-A proxy can close its server-facing socket once all datagram flows mapped to
+A proxy can close its server-facing socket once all proxied connections mapped to
 that socket have been removed.
 
 ## Handling Connection Migration
@@ -522,55 +505,70 @@ path to avoid creating unintentional congestion on the new path.
 # Example
 
 Consider a client that is establishing a new QUIC connection through the proxy.
-It has selected a Client Connection ID of 0x31323334. It selects the next open
-datagram flow ID (2). In order to inform a proxy of the new QUIC Client
-Connection ID, and binds that connection ID to datagram flow ID 2, the client
-sends the following CONNECT-UDP request:
-
-~~~
-HEADERS
-:method = CONNECT-UDP
-:authority = target.example.com:443
-client-connection-id = :MTIzNA==:
-datagram-flow-id = 2
-~~~
+It has selected a Client Connection ID of 0x31323334. In order to inform a proxy
+of the new QUIC Client Connection ID, the client also sends a sends a
+REGISTER_CLIENT_CID capsule.
 
 The client will also send the initial QUIC packet with the Long Header form in
-a DATAGRAM frame with flow ID 2.
+a DATAGRAM frame on the corresponding quarter stream ID.
 
-Once the proxy sends a 200 response indicating success, packets received by the
-proxy that match the Connection ID 0x31323334 will be directly forwarded to the
-client. The proxy will also forward the initial QUIC packet received on DATAGRAM
-flow ID 2 to target.example.com:443.
+~~~
+Client                                             Server
 
-When the proxy receives a response from target.example.com:443 that has
-0x31323334 as the Destination Connection ID, the proxy will forward that packet
-to the client on DATAGRAM flow ID 2.
+STREAM(44): HEADERS             -------->
+  :method = CONNECT
+  :protocol = connect-udp
+  :scheme = https
+  :path = /target.example.com/443/
+  :authority = proxy.example.org
+
+STREAM(44): DATA                -------->
+  Capsule Type = REGISTER_DATAGRAM_NO_CONTEXT
+  Datagram Format Type = UDP_PAYLOAD
+  Datagram Format Additional Data = ""
+  
+STREAM(44): DATA                -------->
+  Capsule Type = REGISTER_CLIENT_CID
+  Connection ID = 0x31323334
+
+DATAGRAM                        -------->
+  Quarter Stream ID = 11
+  Payload = Encapsulated QUIC initial
+
+           <--------  STREAM(44): HEADERS
+                        :status = 200
+                        
+           <--------  STREAM(44): DATA
+                        Capsule Type = ACK_CLIENT_CID
+                        Connection ID = 0x31323334
+
+/* Wait for target server to respond to UDP packet. */
+
+           <--------  DATAGRAM
+                        Quarter Stream ID = 11
+                        Payload = Encapsulated QUIC initial
+~~~
 
 Once the client learns which Connection ID has been selected by the target
-server, it can send a new request to the proxy to establish a mapping. In this
-case, that ID is 0x61626364. The client sends the following request:
+server, it can send a new request to the proxy to establish a mapping for
+forwarding. In this case, that ID is 0x61626364. The client sends the
+following capsule:
 
 ~~~
-HEADERS
-:method = CONNECT-UDP
-:authority = target.example.com:443
-server-connection-id = :YWJjZA==:
-datagram-flow-id = 2
+STREAM(44): DATA                -------->
+  Capsule Type = REGISTER_SERVER_CID
+  Connection ID = 0x61626364
+  
+           <--------  STREAM(44): DATA
+                        Capsule Type = ACK_SERVER_CID
+                        Connection ID = 0x61626364
 ~~~
 
-The client also sends its reply to the target server in a DATAGRAM frame on flow
-ID 2 after sending the new request.
-
-Once the proxy sends a 200 response indicating success, packets sent by the
-client that match the Connection ID 0x61626364 will be forwarded to the target
-server, i.e., without proxy decryption.
-
-Upon receiving the response, the client starts sending Short Header packets with
-a Destination Connection ID of 0x61626364 directly to the proxy (not tunnelled),
-and these are forwarded directly to the target by the proxy. Similarly, Short
-Header packets from the target with a Destination Connection ID of 0x31323334
-are forwarded directly to the client.
+Upon receiving a ACK_SERVER_CID capsule, the client starts sending Short Header
+packets with a Destination Connection ID of 0x61626364 directly to the proxy
+(not tunnelled), and these are forwarded directly to the target by the proxy.
+Similarly, Short Header packets from the target with a Destination Connection ID
+of 0x31323334 are forwarded directly to the client.
 
 # Interactions with Load Balancers
 
@@ -586,19 +584,19 @@ the end servers, not the proxy. If the load balancer is not aware of these
 Connection IDs, or the Connection IDs conflict with other Connection IDs used by
 the load balancer, packets can be routed incorrectly.
 
-QUIC-aware CONNECT-UDP proxies that use forwarding mode generally SHOULD NOT be
+QUIC-aware proxies that use forwarding mode generally SHOULD NOT be
 run behind load balancers; and if they are, they MUST coordinate between the
 proxy and the load balancer to create mappings for proxied Connection IDs prior
 to the proxy sending 2xx (Successful) responses to clients.
 
-QUIC-aware CONNECT-UDP proxies that do not allow forwarding mode can function
-unmodified behind QUIC load balancers.
+QUIC-aware proxies that do not allow forwarding mode can function unmodified
+behind QUIC load balancers.
 
 # Packet Size Considerations
 
 Since Initial QUIC packets must be at least 1200 bytes in length, the DATAGRAM
-frames that are used for a QUIC-aware CONNECT-UDP proxy MUST be able to carry
-at least 1200 bytes.
+frames that are used for a QUIC-aware proxy MUST be able to carry at least 1200
+bytes.
 
 Additionally, clients that connect to a proxy for purpose of proxying QUIC
 SHOULD start their connection with a larger packet size than 1200 bytes, to
@@ -618,7 +616,7 @@ or restrict clients from opening an excessive number of proxied connections, so
 as to limit abuse or use of proxies to launch Denial-of-Service attacks.
 
 Sending QUIC packets by forwarding through a proxy without tunnelling exposes
-some QUIC header metadata to onlookers, and can be used to correlate packets
+some QUIC header metadata to onlookers, and can be used to correlate packet
 flows if an attacker is able to see traffic on both sides of the proxy.
 Tunnelled packets have similar inference problems. An attacker on both sides
 of the proxy can use the size of ingress and egress packets to correlate packets
@@ -637,21 +635,57 @@ or decreasing the reputation of a given proxy.
 
 # IANA Considerations {#iana}
 
-## HTTP Headers {#iana-header}
+## Capsule Types {#iana-capsule-types}
 
-This document registers the "Client-Connection-Id" and "Server-Connection-Id"
-headers in the "Permanent Message Header Field Names"
-<[](https://www.iana.org/assignments/message-headers)>.
+This document registers six new values in the in the "HTTP Capsule Types"
+registry established by {{HTTP-DGRAM}}.
 
-~~~
-  +----------------------+----------+--------+---------------+
-  | Header Field Name    | Protocol | Status |   Reference   |
-  +----------------------+----------+--------+---------------+
-  | Client-Connection-Id |   http   |  exp   | This document |
-  +----------------------+----------+--------+---------------+
-  | Server-Connection-Id |   http   |  exp   | This document |
-  +----------------------+----------+--------+---------------+
-~~~
+|     Capule Type     |   Value   | Specification |
+|:--------------------|:----------|:--------------|
+| REGISTER_CLIENT_CID | 0xffe100  | This Document |
+| REGISTER_SERVER_CID | 0xffe101  | This Document |
+| ACK_CLIENT_CID      | 0xffe102  | This Document |
+| ACK_SERVER_CID      | 0xffe103  | This Document |
+| CLOSE_CLIENT_CID    | 0xffe104  | This Document |
+| CLOSE_SERVER_CID    | 0xffe105  | This Document |
+{: #iana-format-type-table title="Registered Capsule Type"}
+
+## Context Close Codes {#iana-close-codes}
+
+This document establishes a registry for HTTP connection ID close codes.
+The "HTTP QUIC Connection ID Close Codes" registry governs a 62-bit space.
+Registrations in this registry MUST include the following fields:
+
+Type:
+
+: A name or label for the close code.
+
+Value:
+
+: The value of the Close Code field (see {{close-capsule}}) is a 62-bit integer.
+
+Reference:
+
+: An optional reference to a specification for the parameter. This field MAY be
+empty.
+
+Registrations follow the "First Come First Served" policy (see Section 4.4 of
+{{!IANA-POLICY=RFC8126}}) where two registrations MUST NOT have the same Type
+nor Value.
+
+This registry initially contains the following entries:
+
+| Context Close Code   |   Value   | Specification |
+|:---------------------|:----------|:--------------|
+| NO_ERROR             | 0xff8800  | This Document |
+| CONFLICT             | 0xff8801  | This Document |
+| DENIED               | 0xff8802  | This Document |
+{: #iana-close-codes-table title="QUIC Connection ID Close Code Registry Entries"}
+
+Context close codes with a value of the form 41 * N + 19 for integer values of
+N are reserved to exercise the requirement that unknown context close codes be
+treated as NO_ERROR. These values MUST NOT be assigned by IANA and MUST NOT
+appear in the listing of assigned values.
 
 --- back
 


### PR DESCRIPTION
Taking a pass a rewriting QUIC-aware proxying using the H3 capsule format