### PR TITLE
client communication of target-provided stateless reset token

### DIFF
--- a/draft-pauly-masque-quic-proxy.md
+++ b/draft-pauly-masque-quic-proxy.md
@@ -363,7 +363,7 @@ Register Target Connection ID Capsule {
   Stateless Reset Token (..),
 }
 ~~~
-{: #fig-capsule-cid title="Register Target Connection ID Capsule Format"}
+{: #fig-capsule-register-target-cid title="Register Target Connection ID Capsule Format"}
 
 Connection ID Length
 : The length of the connection ID being registered, which is between 0 and

--- a/draft-pauly-masque-quic-proxy.md
+++ b/draft-pauly-masque-quic-proxy.md
@@ -298,9 +298,9 @@ by a Stateless Reset token, to make it indistinguishable from a regular packet
 with a short header. In order for the proxy to correctly recognize Stateless
 Reset packets, the client SHOULD share the Stateless Reset token for each
 registered Target Connection ID. When the proxy receives a Stateless Reset packet,
-it SHOULD tunnel the packet to the client regardless of whether or not forwarding
-is enabled.
-
+it can send the packet to the client as a tunnelled datagram. Although Stateless Reset packets
+look like short header packets, they are not technically short header packets and do not contain
+negotiated connection IDs, and thus are not eligible for forwarded mode.
 # Connection ID Capsule Types
 
 Proxy awareness of QUIC Connection IDs relies on using capsules ({{HTTP-DGRAM}})

--- a/draft-pauly-masque-quic-proxy.md
+++ b/draft-pauly-masque-quic-proxy.md
@@ -298,7 +298,8 @@ by a Stateless Reset token, to make it indistinguishable from a regular packet
 with a short header. In order for the proxy to correctly recognize Stateless
 Reset packets, the client SHOULD share the Stateless Reset token for each
 registered Target Connection ID. When the proxy receives a Stateless Reset packet,
-it SHOULD forward or tunnel the packet to the client.
+it SHOULD tunnel the packet to the client regardless of whether or not forwarding
+is enabled.
 
 # Connection ID Capsule Types
 
@@ -379,7 +380,7 @@ Stateless Reset Token Length
 
 Stateless Reset Token
 : The target-provided Stateless Reset token allowing the proxy to correctly
-recognize Stateless Reset packets to be forwarded or tunneled to the client.
+recognize Stateless Reset packets to be tunneled to the client.
 
 The REGISTER_CLIENT_CID and ACK_TARGET_CID capsule types include a Virtual
 Connection ID and Stateless Reset Token.


### PR DESCRIPTION
Addresses #48, however, instead of converting stateless reset packets to a stream error, they are simply tunneled or forwarded to the client.

A couple questions come to mind:

**Should receipt of a stateless reset packet result in a stream error?**

- Offers reliably delivered signal to the client that the connection is broken.
- Allows the proxy to terminate the stream immediately and avoid having to consider handling of many stateless reset packets
- What H3 error code? `H3_CONNECT_ERROR`?

**If not a stream error, is tunneled _OR_ forwarded OK?**

- If we require they be tunneled, does that make things easier for the client at no cost to the proxy?
- Is there any reason why we wouldn't want the stateless reset packet sent "in the clear" (forwarded)?