### PR TITLE
update forwarded mode migration guidance

### DIFF
--- a/draft-pauly-masque-quic-proxy.md
+++ b/draft-pauly-masque-quic-proxy.md
@@ -462,14 +462,14 @@ Connection ID capsules.
 The client sends a REGISTER_CLIENT_CID capsule whenever it advertises a new
 Client Connection ID to the target, and a REGISTER_TARGET_CID capsule when
 it has received a new Target Connection ID for the target. In order to change
-the connection ID bytes on the wire, a client may change the Virtual Client
-Connection ID by sending a REGISTER_CLIENT_CID with the same Connection ID,
-but different Virtual Connection ID. Similarly, the client may solicit a new
+the connection ID bytes on the wire, a client can update a previously advertised Virtual Client
+Connection ID by sending a new REGISTER_CLIENT_CID with the same Connection ID,
+but a different Virtual Connection ID. Similarly, the client may solicit a new
 Virtual Target Connection ID by sending a REGISTER_TARGET_CID capsule with
-the previously registered Target Connection ID. Clients are responsible for
+a previously registered Target Connection ID. Clients are responsible for
 changing Virtual Connection IDs when the HTTP stream's network path changes to
-avoid linkability across network paths. Note that the initial
-REGISTER_CLIENT_CID capsule MAY be sent prior to receiving an HTTP response
+avoid linkability across network paths. Note that initial
+REGISTER_CLIENT_CID capsules MAY be sent prior to receiving an HTTP response
 from the proxy.
 
 ## New Proxied Connection Setup
@@ -684,17 +684,17 @@ path to avoid creating unintentional congestion on the new path.
 
 When operating in forwarded mode, the proxy reconfigures or removes forwarding
 rules as the network path between the client and proxy changes. In the event of
-a passive migration, the proxy automatically reconfigures forwarding rules to use
+passive migration, the proxy automatically reconfigures forwarding rules to use
 the latest active and validated network path for the HTTP stream. In the event of
-an active migration, the proxy removes forwarding rules in order to not send
+active migration, the proxy removes forwarding rules in order to not send
 packets with the same connection ID bytes over multiple network paths. After
-initiating an active migration, clients are no longer able to send forwarded mode
-packets since the proxy will have removed the rules. Clients may proceed with
-tunneled mode or may request new forwarding rules via REGISTER_CLIENT_CID and
-REGISTER_TARGET_CID capsules. Each of these capsules shall contain new virtual
+initiating active migration, clients are no longer able to send forwarded mode
+packets since the proxy will have removed forwarding rules. Clients can proceed with
+tunnelled mode or can request new forwarding rules via REGISTER_CLIENT_CID and
+REGISTER_TARGET_CID capsules. Each of these capsules will contain new virtual
 connection IDs to prevent packets with the same connection ID bytes being used
 over multiple network paths. Note that the Client Connection ID and Target
-Connection ID may stay the same while the Virtual Target Connection ID and
+Connection ID can stay the same while the Virtual Target Connection ID and
 Virtual Client Connection ID change.
 
 # Example

--- a/draft-pauly-masque-quic-proxy.md
+++ b/draft-pauly-masque-quic-proxy.md
@@ -461,9 +461,16 @@ Connection ID capsules.
 
 The client sends a REGISTER_CLIENT_CID capsule whenever it advertises a new
 Client Connection ID to the target, and a REGISTER_TARGET_CID capsule when
-it has received a new Target Connection ID for the target. Note that the
-initial REGISTER_CLIENT_CID capsule MAY be sent prior to receiving an
-HTTP response from the proxy.
+it has received a new Target Connection ID for the target. In order to change
+the connection ID bytes on the wire, a client may change the Virtual Client
+Connection ID by sending a REGISTER_CLIENT_CID with the same Connection ID,
+but different Virtual Connection ID. Similarly, the client may solicit a new
+Virtual Target Connection ID by sending a REGISTER_TARGET_CID capsule with
+the previously registered Target Connection ID. Clients are responsible for
+changing Virtual Connection IDs when the HTTP stream's network path changes to
+avoid linkability across network paths. Note that the initial
+REGISTER_CLIENT_CID capsule MAY be sent prior to receiving an HTTP response
+from the proxy.
 
 ## New Proxied Connection Setup
 
@@ -675,18 +682,20 @@ to an unvalidated client address to the size of an initial congestion window.
 Proxies additionally SHOULD pace the rate at which packets are sent over a new
 path to avoid creating unintentional congestion on the new path.
 
-When operating in forwarded mode, the proxy MUST NOT send forwarded mode
-packets with the same Destination Connection ID over multiple network paths.
-
-After switching to a new network path, the proxy MUST tunnel Target to Client
-packets instead of forwarding. Only once a new Virtual Client Connection ID has
-been communicated to the proxy via a REGISTER_CLIENT_CID capsule may the proxy
-begin forwarding packets to the client. Similarly, when a client actively
-migrates, it MUST NOT send any forwarded mode packets until it has registered
-a new Virtual Target Connection ID. In both cases, reusing a connection ID would
-increase linkability of the connection between network paths. Note that the
-Client Connection ID and Target Connection ID may stay the same while the
-Virtual Target Connection ID and Virtual Client Connection ID change.
+When operating in forwarded mode, the proxy reconfigures or removes forwarding
+rules as the network path between the client and proxy changes. In the event of
+a passive migration, the proxy automatically reconfigures forwarding rules to use
+the latest active and validated network path for the HTTP stream. In the event of
+an active migration, the proxy removes forwarding rules in order to not send
+packets with the same connection ID bytes over multiple network paths. After
+initiating an active migration, clients are no longer able to send forwarded mode
+packets since the proxy will have removed the rules. Clients may proceed with
+tunneled mode or may request new forwarding rules via REGISTER_CLIENT_CID and
+REGISTER_TARGET_CID capsules. Each of these capsules shall contain new virtual
+connection IDs to prevent packets with the same connection ID bytes being used
+over multiple network paths. Note that the Client Connection ID and Target
+Connection ID may stay the same while the Virtual Target Connection ID and
+Virtual Client Connection ID change.
 
 # Example
 


### PR DESCRIPTION
addresses #68 by clarifying active vs. passive migration guidance and describing how to change virtual CIDs without changing real CIDs